### PR TITLE
Update photon library

### DIFF
--- a/neutron-physics/model.py
+++ b/neutron-physics/model.py
@@ -242,9 +242,12 @@ class Model(object):
         lines = ['Point source in infinite geometry']
  
         # Create the cell cards: material 1 inside sphere, void outside
-        kT = self._temperature * openmc.data.K_BOLTZMANN * 1e-6
         lines.append('c --- Cell cards ---')
-        lines.append(f'1 1 -{self.density} -1 imp:n=1 tmp={kT}')
+        if self._temperature is not None:
+            kT = self._temperature * openmc.data.K_BOLTZMANN * 1e-6
+            lines.append(f'1 1 -{self.density} -1 imp:n=1 tmp={kT}')
+        else:
+            lines.append(f'1 1 -{self.density} -1 imp:n=1')
         lines.append('2 0 1 imp:n=0')
  
         # Create the surface cards: sphere centered on origin with 1e9 cm
@@ -350,12 +353,13 @@ class Model(object):
  
         # Save plot
         os.makedirs('plots', exist_ok=True)
-        if self.name is None:
-            name = (f'{self.nuclide}-{self.energy:.1e}eV-'
-                    f'{self._temperature:.1f}K.png')
+        if self.name is not None:
+            name = self.name
         else:
-            name = f'{self.name}.png'
-        plt.savefig(Path('plots') / name, bbox_inches='tight')
+            name = f'{self.nuclide}-{self.energy:.1e}eV'
+            if self._temperature is not None:
+                name +=  f'-{self._temperature:.1f}K'
+        plt.savefig(Path('plots') / (name + '.png'), bbox_inches='tight')
         plt.close()
 
     def run(self):

--- a/neutron-physics/model.py
+++ b/neutron-physics/model.py
@@ -200,7 +200,7 @@ class Model(object):
         materials.export_to_xml(Path('openmc') / 'materials.xml')
 
         # Set up geometry
-        sphere = openmc.Sphere(boundary_type='reflective', R=1.e9)
+        sphere = openmc.Sphere(boundary_type='reflective', r=1.e9)
         cell = openmc.Cell(fill=materials, region=-sphere)
         geometry = openmc.Geometry([cell])
         geometry.export_to_xml(Path('openmc') / 'geometry.xml')
@@ -359,7 +359,7 @@ class Model(object):
             name = f'{self.nuclide}-{self.energy:.1e}eV'
             if self._temperature is not None:
                 name +=  f'-{self._temperature:.1f}K'
-        plt.savefig(Path('plots') / (name + '.png'), bbox_inches='tight')
+        plt.savefig(Path('plots') / f'{name}.png', bbox_inches='tight')
         plt.close()
 
     def run(self):

--- a/photon-physics/model.py
+++ b/photon-physics/model.py
@@ -349,11 +349,11 @@ class Model(object):
  
         # Save plot
         os.makedirs('plots', exist_ok=True)
-        if self.name is None:
-            name = f'{self.material}-{self.energy_mev:.1e}MeV.png'
+        if self.name is not None:
+            name = self.name
         else:
-            name = f'{self.name}.png'
-        plt.savefig(Path('plots') / name, bbox_inches='tight')
+            name = f'{self.material}-{self.energy_mev:.1e}MeV'
+        plt.savefig(Path('plots') / (name + '.png'), bbox_inches='tight')
         plt.close()
 
     def run(self):

--- a/photon-physics/model.py
+++ b/photon-physics/model.py
@@ -102,56 +102,6 @@ class Model(object):
             # Convert cross section data
             data = openmc.data.IncidentPhoton.from_ace(table)
 
-            # Add data used for calculating stopping powers used in OpenMC
-            data_path = Path(openmc.data.__file__).parent
-            path = data_path / 'density_effect.h5'
-            with h5py.File(path, 'r') as f:
-                group = f['{:03}'.format(Z)]
-                data.bremsstrahlung.update({
-                    'I': group.attrs['I'],
-                    'num_electrons': group['num_electrons'].value,
-                    'ionization_energy': group['ionization_energy'].value
-                })
-
-            # Add bremsstrahlung cross sections used in OpenMC
-            path = data_path / 'BREMX.DAT'
-            brem = open(path, 'r').read().split()
-
-            # Incident electron kinetic energy grid in eV
-            data.bremsstrahlung['electron_energy'] = np.logspace(3, 9, 200)
-            log_energy = np.log(data.bremsstrahlung['electron_energy'])
-
-            # Get number of tabulated electron and photon energy values
-            n = int(brem[37])
-            k = int(brem[38])
-
-            # Index in data
-            p = 39
-
-            # Get log of incident electron kinetic energy values, used for
-            # cubic spline interpolation in log energy. Units are in MeV, so
-            # convert to eV.
-            logx = np.log(np.fromiter(brem[p:p+n], float, n)*1.e6)
-            p += n
-
-            # Get reduced photon energy values
-            data.bremsstrahlung['photon_energy'] = np.fromiter(brem[p:p+k], float, k)
-            p += k
-
-            # Get the scaled cross section values for each electron energy
-            # and reduced photon energy for this Z. Units are in mb, so
-            # convert to b.
-            p += (Z - 1)*n*k
-            y = np.reshape(np.fromiter(brem[p:p+n*k], float, n*k), (n, k))*1.0e-3
-
-            data.bremsstrahlung['dcs'] = np.empty([len(log_energy), k])
-            for j in range(k):
-                # Cubic spline interpolation in log energy and linear DCS
-                cs = CubicSpline(logx, y[:,j])
-
-                # Get scaled DCS values (millibarns) on new energy grid
-                data.bremsstrahlung['dcs'][:,j] = cs(log_energy)
-
             # Export HDF5 file
             os.makedirs('openmc', exist_ok=True)
             h5_file = Path('openmc') / f'{data.name}.h5'
@@ -191,7 +141,7 @@ class Model(object):
         materials.export_to_xml(Path('openmc') / 'materials.xml')
 
         # Set up geometry
-        sphere = openmc.Sphere(boundary_type='reflective', R=1.e9)
+        sphere = openmc.Sphere(boundary_type='reflective', r=1.e9)
         cell = openmc.Cell()
         cell.fill = mat
         cell.region = -sphere
@@ -353,7 +303,7 @@ class Model(object):
             name = self.name
         else:
             name = f'{self.material}-{self.energy_mev:.1e}MeV'
-        plt.savefig(Path('plots') / (name + '.png'), bbox_inches='tight')
+        plt.savefig(Path('plots') / f'{name}.png', bbox_inches='tight')
         plt.close()
 
     def run(self):

--- a/photon-production/model.py
+++ b/photon-production/model.py
@@ -234,22 +234,16 @@ class Model(object):
                 # Convert cross section data
                 data = openmc.data.IncidentPhoton.from_ace(table)
 
-                # Add stopping powers for thick-target bremsstrahlung
-                # approximation used in OpenMC
+                # Add data used for calculating stopping powers used in OpenMC
                 data_path = Path(openmc.data.__file__).parent
-                if Z < 99:
-                    path = data_path / 'stopping_powers.h5'
-                    with h5py.File(path, 'r') as f:
-                        # Units are in MeV; convert to eV
-                        data.stopping_powers['energy'] = f['energy'].value*1.e6
-
-                        # Units are in MeV cm^2/g; convert to eV cm^2/g
-                        group = f[f'{Z:03}']
-                        data.stopping_powers.update({
-                            'I': group.attrs['I'],
-                            's_collision': group['s_collision'].value*1.e6,
-                            's_radiative': group['s_radiative'].value*1.e6
-                        })
+                path = data_path / 'density_effect.h5'
+                with h5py.File(path, 'r') as f:
+                    group = f['{:03}'.format(Z)]
+                    data.bremsstrahlung.update({
+                        'I': group.attrs['I'],
+                        'num_electrons': group['num_electrons'].value,
+                        'ionization_energy': group['ionization_energy'].value
+                    })
 
                 # Add bremsstrahlung cross sections used in OpenMC
                 path = data_path / 'BREMX.DAT'


### PR DESCRIPTION
When generating the photon library, we now read in the data used for calculating the density effect correction and collision stopping power instead of the stopping powers from ESTAR. There is also a fix in the photon production model to allow source neutrons with energies below the photon cutoff energy.