### PR TITLE
Add new script openmc-report-benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ benchmarks/
 
 # macOS
 *.DS_Store
+
+# tex outputs
+*.tex

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ benchmarks/
 
 # tex outputs
 *.tex
+
+# Jupyter Notebooks
+*.ipynb*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository contains a collection of validation scripts, notebooks, results, etc. that have been used in the preparation of reports and articles. The following scripts are currently available:
 
 - `openmc-run-benchmarks` -- Run a collection of ICSBEP benchmarks with OpenMC or MCNP6
-- `openmc-plot-benchmarks` -- Plot results from `openmc-run-becnhmarks`
+- `openmc-plot-benchmarks` -- Plot results from `openmc-run-benchmarks`
+- `openmc-report-benchmarks` -- Create .tex file comparing results from `openmc-run-benchmarks` to experimental values
 - `openmc-validate-neutron-physics` -- Used for validating neutron transport in OpenMC. The script generates an infinite medium problem of a single nuclide with a point source at a single energy and compares the resulting neutron energy spectra from OpenMC and either MCNP6 or Serpent 2. This script requires that you have MCNP6 or Serpent 2 installed (`mcnp6` or `sss2` executable available).
 - `openmc-validate-photon-physics` -- Used for validating photon transport in OpenMC. The script generates an infinite medium problem of a single element with a point source at a single energy and compares the resulting photon energy spectra from OpenMC and either MCNP6 or Serpent 2. This script requires that you have MCNP6 or Serpent 2 installed (`mcnp6` or `sss2` executable available).
 - `openmc-validate-photon-production` -- Used for validating photon production in OpenMC. This script generates a broomstick problem where monoenergetic neutrons are shot down a thin, infinitely long cylinder. The energy spectra of photons produced from neutron reactions is tallied along the surface of the cylinder. Comparisons are made between OpenMC and either MCNP6 or Serpent 2. Again, this script requires that MCNP6 or Serpent 2 is properly installed.

--- a/benchmarking/plot.py
+++ b/benchmarking/plot.py
@@ -85,8 +85,8 @@ def plot(files, labels=None, plot_type='keff', match=None, show_mean=True,
             keff_i = df['keff'].loc[index]
             stdev_i = 1.96*df['stdev'].loc[index]
 
-            diff = keff_i - keff0
-            err = np.sqrt(stdev_i**2 + stdev0**2)
+            diff = (keff_i - keff0) * 1e5
+            err = np.sqrt(stdev_i**2 + stdev0**2) * 1e5
             kwargs['label'] = labels[i + 1] + ' - ' + labels[0]
             if show_uncertainties:
                 ax.errorbar(x, diff, yerr=err, color=f'C{i}', **kwargs)
@@ -105,7 +105,7 @@ def plot(files, labels=None, plot_type='keff', match=None, show_mean=True,
                     ax.plot([-1, n], [mu, mu], '-', color=f'C{i}', lw=1.5)
 
         # Define y-axis label
-        ylabel = r'$\Delta k_\mathrm{eff}$'
+        ylabel = r'$\Delta k_\mathrm{eff}$ [pcm]'
 
     else:
         for i, (label, df) in enumerate(dataframes.items()):
@@ -189,6 +189,6 @@ def main():
         show_uncertainties=args.show_uncertainties,
     )
     if args.output is not None:
-        plt.savefig(args.output, bbox_inches='tight')
+        plt.savefig(args.output, bbox_inches='tight', transparent=True)
     else:
         plt.show()

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -6,31 +6,6 @@ from openmc import __version__
 
 from .results import get_result_dataframe, get_icsbep_dataframe
 
-
-def num_format(num):
-    """Format long decimal values with thin spaces.
-
-    Parameters
-    ----------
-    num : float
-        Float value to be formatted for LaTeX
-
-    Returns
-    ----------
-    tex_num : str
-        TeX-readable num with thin space
-
-    """
-    num = f'{num:.9f}'
-    dec_pos = num.find('.')
-    if dec_pos != -1:
-        if len(num[dec_pos+4:]) > 0:
-            tex_num = (num[:dec_pos+4] + r'\,' + num[dec_pos+4:dec_pos+7])
-    else:
-        tex_num = num
-    return tex_num
-
-
 def write_document(result, output, match=None):
     """Write LaTeX document section with preamble, run info, and table
     entries for all benchmark data comparing the calculated and
@@ -55,6 +30,7 @@ def write_document(result, output, match=None):
         r'\usepackage{booktabs}',
         r'\usepackage{longtable}',
         r'\usepackage{fancyhdr}',
+        r'\usepackage{siunitx}',
         r'\setlength\LTcapwidth{5.55in}',
         r'\setlength\LTleft{0.5in}',
         r'\setlength\LTright{0.5in}'
@@ -108,16 +84,16 @@ def write_document(result, output, match=None):
         r'& Exp. $k_{\textrm{eff}}$&Exp. unc.& Calc. $k_{\textrm{eff}}$&Calc. unc.\\',
         r'\midrule',
         '% DATA',
-        '\\end{longtable}'
+        r'\end{longtable}'
     ]
 
     for case in index:
         # Obtain and format calculated values
-        keff = df['keff'].loc[case]
-        keff = num_format(keff)
+        keff = '{:.6f}'.format(df['keff'].loc[case])
+        keff = r'\num{' + keff + '}'
 
-        stdev = df['stdev'].loc[case]
-        stdev = num_format(stdev)
+        stdev = '{:.6f}'.format(df['stdev'].loc[case])
+        stdev = r'\num{' + stdev + '}'
 
         # Obtain and format experimental values
         icsbep_keff = '{:.4f}'.format(icsbep['keff'].loc[case])

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 import numpy as np
+from openmc import __version__
 
 from .results import get_result_dataframe, get_icsbep_dataframe, abbreviated_name
 
@@ -34,9 +35,9 @@ def num_format(num):
     return tex_num
 
 def write_document(results, output, labels=None, match=None):
-    """Write LaTeX document section with preamble, run info, and table entries 
-    for all benchmark data comparing the calculated and experimental values 
-    along with uncertainties.
+    """Write LaTeX document section with preamble, run info, and table 
+    entries for all benchmark data comparing the calculated and 
+    experimental values along with uncertainties.
 
     Parameters
     ----------
@@ -103,11 +104,14 @@ def write_document(results, output, labels=None, match=None):
         cond = index.map(lambda x: fnmatch(x, match))
         index = index[cond]
 
-    # Custom Table Caption
-    caption = '\\caption{\\label{tab:1} Criticality (' + labels[0] + ') Benchmark Results}\\\\'
+    # Custom Table Description and Caption
+    desc = ('Table \\ref{tab:1} uses (nuclear data info here) and openmc ' 
+            f'version {__version__} to evaluate ICSBEP benchmarks.')
+    caption = ('\\caption{\\label{tab:1} Criticality (' + labels[0] + ') Benchmark Results}\\\\')
+
     # Define Table Entry
     table = [
-            'Table \\ref{tab:1} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
+            desc,
             '\\begin{longtable}{lcccc}',
             caption,
             '\\endfirsthead',

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -10,31 +10,30 @@ import numpy as np
 
 from .results import get_result_dataframe, get_icsbep_dataframe, abbreviated_name
 
-def num_format(number):
+def num_format(num):
     """Format long decimal values with thin spaces.
     
     Parameters
     ----------
-    number  : float
+    num  : float
         Float value to be formatted for LaTeX
-    
+
     Returns
     ----------
-    tex_number   : str
-        TeX-readable number with thin space
+    tex_num   : str
+        TeX-readable num with thin space
     
     """
-    number = round(number, 6)
-    number = str(number)
-    decimal_index = number.find('.') 
-    if decimal_index != -1:
-        if len(number[decimal_index+4:]) > 0:
-            tex_number = number[:decimal_index+4] + '\\,' +number[decimal_index+4:]
-        else:
-            tex_number = number
-    return tex_number
+    num = '{0:.9f}'.format(num)
+    dec_pos= num.find('.') 
+    if dec_pos != -1:
+        if len(num[dec_pos+4:]) > 0:
+            tex_number = (num[:dec_pos+4] + '\\,' + num[dec_pos+4:dec_pos+7])
+    else:
+        tex_num = num
+    return num
 
-def write_document(results, output='report.tex', labels=None, match=None):
+def write_document(results, output, labels=None, match=None):
     """Write LaTeX document section with preamble, run info, and table entries 
     for all benchmark data comparing the calculated and experimental values 
     along with uncertainties.
@@ -55,11 +54,14 @@ def write_document(results, output='report.tex', labels=None, match=None):
     None
 
     """
-    #write .tex file
+    #write file
+    if output is None:
+        output = 'report.tex'
     tex = open(output, 'w')
 
     #define document preamble
-    preamble = ['\\documentclass[12pt]{article}', 
+    preamble = [
+                '\\documentclass[12pt]{article}', 
                 '\\usepackage[letterpaper, margin=1in]{geometry}',
                 '\\usepackage{dcolumn}',
                 '\\usepackage{tabularx}',
@@ -68,20 +70,23 @@ def write_document(results, output='report.tex', labels=None, match=None):
                 '\\usepackage{fancyhdr}',
                 '\\setlength\\LTcapwidth{5.55in}',
                 '\\setlength\\LTleft{0.5in}',
-                '\\setlength\\LTright{0.5in}']
+                '\\setlength\\LTright{0.5in}'
+                ]
 
     #define document start and end tex
-    doc_start = ['\\begin{document}',
-                 '\\part*{Benchmark Results}']
+    doc_start = [
+                '\\begin{document}',
+                '\\part*{Benchmark Results}'
+                ]
     
     doc_end = ['\\end{document}']
 
     if labels is None:
-        labels = [Path(f).name for f in files]
+        labels = [Path(f).name for f in results]
 
     # Read data from spreadsheets
     dataframes = {}
-    for csvfile, label in zip(files, labels):
+    for csvfile, label in zip(results, labels):
         dataframes[label] = get_result_dataframe(csvfile).dropna()
 
     # Get model keff and uncertainty from ICSBEP
@@ -101,63 +106,62 @@ def write_document(results, output='report.tex', labels=None, match=None):
     # entries are abbreviated_name, column 1
     # experimental value, uncertainty, column 2,3
     # calculated value, uncertainty, column 4, 5
-    
     # Setup x values (integers) and corresponding tick labels
+
     n = index.size # <-- number of cases we need to issue
 
     x = np.arange(1, n + 1)
 
-    table = ['Table \\ref{tab:data} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
-                '\\begin{longtable}{lcccc}',
-                '\\caption{\\label{tab:tomato} Criticality (nuclear data set info here) Benchmark Results}\\\\',
-                '\\endfirsthead',
-                '\\midrule',
-                '\\multicolumn{5}{r}{Continued on Next Page}\\',
-                '\\midrule',
-                '\\endfoot',
-                '\\bottomrule',
-                '\\endlastfoot',
-                '\\toprule',
-                '& Exp. $k_{\\textrm{eff}}$&Exp. unc.& Calc. $k_{\textrm{eff}}$&Calc. unc.\\',
-                '\\midrule',
-                '\\end{longtable}']
+    table = [
+            'Table \\ref{tab:data} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
+            '\\begin{longtable}{lcccc}',
+            '\\caption{\\label{tab:data} Criticality (nuclear data set info here) Benchmark Results}\\\\',
+            '\\endfirsthead',
+            '\\midrule',
+            '\\multicolumn{5}{r}{Continued on Next Page}\\',
+            '\\midrule',
+            '\\endfoot',
+            '\\bottomrule',
+            '\\endlastfoot',
+            '\\toprule',
+            '& Exp. $k_{\\textrm{eff}}$&Exp. unc.& Calc. $k_{\textrm{eff}}$&Calc. unc.\\\\',
+            '\\midrule',
+            '\\end{longtable}'
+            ]
 
     for i, (label, df) in enumerate(dataframes.items()):
-        keff = df['keff'].loc[index] #calculated
+        keff = df['keff'] #calculated
         keff = num_format(keff)
-        stdev = df['stdev'].loc[index] #calculated?
+        stdev = df['stdev'] #calculated?
         stdev = num_format(stdev)
 
-        icsbep_keff = icsbep['keff'].loc[index]
-        icsbep_stdev = icsbep['stdev'].loc[index]
+        icsbep_keff = icsbep['keff']
+        icsbep_stdev = icsbep['stdev']
 
-        table.insert(-2, (f'{label}&{icsbep_keff}&{icsbep_stdev}&{keff}&{stdev}\\\\'))
+        table.insert(-1, (f'{index}&{icsbep_keff}&{icsbep_stdev}&{keff}&{stdev}\\\\'))
 
     
-    tex.writelines(s + '\n' for s in (preamble + doc_start + table + doc_end))
-
+    tex.writelines(line + '\n' for line in (preamble + doc_start + table + doc_end))
     tex.close()
 
 def main():
     """Produce LaTeX document with tabulated benchmark results"""
 
     parser = ArgumentParser()
-    parser.add_argument('files', nargs='+', help='Result CSV files')
+    parser.add_argument('results', nargs='+', help='Result CSV files')
     parser.add_argument('--labels', help='Comma-separated list of dataset labels')
     parser.add_argument('--match', help='Pattern to match benchmark names to')
     parser.add_argument('-o', '--output', help='Filename to save to')
-    #parser.add_argument('-c', '--compile', help='Compile resulting .tex to pdf')
+    parser.add_argument('-c', '--compile', help='Compile resulting .tex to pdf')
     parser.set_defaults(show_uncertainties=True, show_shaded=True, show_mean=True)
     args = parser.parse_args()
     
     if args.labels is not None:
         args.labels = args.labels.split(',')
-    
-    # Testing purposes
-    tex.writelines(s + '\n' for s in preamble)
+
         
     write_document(
-        args.files,
+        args.results,
         args.output,
         args.labels,
         args.match

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -74,6 +74,7 @@ def write_document(results, output, labels=None, match=None):
                 ]
 
     # Define document start and end snippets
+
     doc_start = ['\\begin{document}', '\\part*{Benchmark Results}']
     
     doc_end = ['\\end{document}']
@@ -95,18 +96,20 @@ def write_document(results, output, labels=None, match=None):
     index = dataframes[base].index #get raw icsbep case names 
 
     for df in dataframes.values(): #get the case/value column of the dataframes
-        index = index.intersection(df.index) #gives you all of the cases that need to be displayed
+        index = index.intersection(df.index) #gives all of the cases that need to be displayed
 
-    # Applying matching as needed
+    # Applying matching as needed (DEPRECATED)
     if match is not None:
         cond = index.map(lambda x: fnmatch(x, match))
         index = index[cond]
 
+    # Custom Table Caption
+    caption = '\\caption{\\label{tab:1} Criticality (' + labels[0] + ') Benchmark Results}\\\\'
     # Define Table Entry
     table = [
-            'Table \\ref{tab:data} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
+            'Table \\ref{tab:1} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
             '\\begin{longtable}{lcccc}',
-            '\\caption{\\label{tab:data} Criticality (nuclear data set info here) Benchmark Results}\\\\',
+            caption,
             '\\endfirsthead',
             '\\midrule',
             '\\multicolumn{5}{r}{Continued on Next Page}\\\\',
@@ -122,7 +125,6 @@ def write_document(results, output, labels=None, match=None):
             '\\end{longtable}'
             ]
 
-    
     for case in index:
         # Obtain and format calculated values
         keff = df['keff'].loc[case]
@@ -147,7 +149,7 @@ def main():
     """Produce LaTeX document with tabulated benchmark results"""
 
     parser = ArgumentParser()
-    parser.add_argument('results', nargs='+', help='Result CSV files')
+    parser.add_argument('results', nargs='+', help='Result CSV file')
     parser.add_argument('--labels', help='Comma-separated list of dataset labels')
     parser.add_argument('--match', help='Pattern to match benchmark names to')
     parser.add_argument('-o', '--output', help='Filename to save to')
@@ -166,5 +168,6 @@ def main():
         args.match
         )
     
+    # TBD
     if args.compile:
         pass

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -1,0 +1,19 @@
+from argparse import ArgumentParser
+from fnmatch import fnmatch
+from math import sqrt
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+import numpy as np
+
+from .results import get_result_dataframe, get_icsbep_dataframe, abbreviated_name
+
+
+import pylatex as pl
+
+
+def main():
+    """Produce .tex file"""
+    

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -1,86 +1,74 @@
 from argparse import ArgumentParser
 from fnmatch import fnmatch
-from math import sqrt
-import os
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-from matplotlib.patches import Polygon
-import numpy as np
 from openmc import __version__
 
-from .results import get_result_dataframe, get_icsbep_dataframe, abbreviated_name
+from .results import get_result_dataframe, get_icsbep_dataframe
+
 
 def num_format(num):
     """Format long decimal values with thin spaces.
-    
+
     Parameters
     ----------
-    num  : float
+    num : float
         Float value to be formatted for LaTeX
 
     Returns
     ----------
-    tex_num   : str
+    tex_num : str
         TeX-readable num with thin space
-    
+
     """
-    num = '{0:.9f}'.format(num)
-    dec_pos= num.find('.') 
+    num = f'{num:.9f}'
+    dec_pos = num.find('.')
     if dec_pos != -1:
         if len(num[dec_pos+4:]) > 0:
-            tex_num = (num[:dec_pos+4] + '\\,' + num[dec_pos+4:dec_pos+7])
+            tex_num = (num[:dec_pos+4] + r'\,' + num[dec_pos+4:dec_pos+7])
     else:
         tex_num = num
     return tex_num
 
+
 def write_document(result, output, match=None):
-    """Write LaTeX document section with preamble, run info, and table 
-    entries for all benchmark data comparing the calculated and 
+    """Write LaTeX document section with preamble, run info, and table
+    entries for all benchmark data comparing the calculated and
     experimental values along with uncertainties.
 
     Parameters
     ----------
     result : str
         Name of a result csv file produced by the benchmarking script.
-    output    : str
+    output : str
         Name of the file to be written, ideally a .tex file
     match : str
         Pattern to match benchmark names to
 
-    Returns
-    -------
-    None
-
     """
-    # Open and write file
-    if output is None:
-        output = 'report.tex'
-    tex = open(output, 'w')
-
     # Define document preamble
     preamble = [
-                '\\documentclass[12pt]{article}', 
-                '\\usepackage[letterpaper, margin=1in]{geometry}',
-                '\\usepackage{dcolumn}',
-                '\\usepackage{tabularx}',
-                '\\usepackage{booktabs}',
-                '\\usepackage{longtable}',
-                '\\usepackage{fancyhdr}',
-                '\\setlength\\LTcapwidth{5.55in}',
-                '\\setlength\\LTleft{0.5in}',
-                '\\setlength\\LTright{0.5in}'
-                ]
+        r'\documentclass[12pt]{article}',
+        r'\usepackage[letterpaper, margin=1in]{geometry}',
+        r'\usepackage{dcolumn}',
+        r'\usepackage{tabularx}',
+        r'\usepackage{booktabs}',
+        r'\usepackage{longtable}',
+        r'\usepackage{fancyhdr}',
+        r'\setlength\LTcapwidth{5.55in}',
+        r'\setlength\LTleft{0.5in}',
+        r'\setlength\LTright{0.5in}'
+    ]
 
     # Define document start and end snippets
-    doc_start = ['\\begin{document}', '\\part*{Benchmark Results}']
-    doc_end = ['\\end{document}']
+    doc_start = [r'\begin{document}', r'\part*{Benchmark Results}']
+    doc_end = [r'\end{document}']
 
     # Convert from list to string
     result = result[0]
 
     label = Path(result).name
-    
+
     # Read data from spreadsheet
     dataframes = {}
     dataframes[label] = get_result_dataframe(result).dropna()
@@ -100,49 +88,48 @@ def write_document(result, output, match=None):
         index = index[cond]
 
     # Custom Table Description and Caption
-    desc = ('Table \\ref{tab:1} uses (nuclear data info here) and openmc ' 
+    desc = (r'Table \ref{tab:1} uses (nuclear data info here) and openmc '
             f'version {__version__} to evaluate ICSBEP benchmarks.')
-    caption = ('\\caption{\\label{tab:1} Criticality (' + label + ') Benchmark Results}\\\\')
+    caption = r'\caption{\label{tab:1} Criticality (' + label + r') Benchmark Results}\\'
 
     # Define Table Entry
     table = [
-            desc,
-            '\\begin{longtable}{lcccc}',
-            caption,
-            '\\endfirsthead',
-            '\\midrule',
-            '\\multicolumn{5}{r}{Continued on Next Page}\\\\',
-            '\\midrule',
-            '\\endfoot',
-            '\\bottomrule',
-            '\\endlastfoot',
-            '\\toprule',
-            '& Exp. $k_{\\textrm{eff}}$&Exp. unc.& Calc. $k_{\\textrm{eff}}$&Calc. unc.\\\\',
-            '\\midrule',
-            '% DATA',
-
-            '\\end{longtable}'
-            ]
+        desc,
+        r'\begin{longtable}{lcccc}',
+        caption,
+        r'\endfirsthead',
+        r'\midrule',
+        r'\multicolumn{5}{r}{Continued on Next Page}\\',
+        r'\midrule',
+        r'\endfoot',
+        r'\bottomrule',
+        r'\endlastfoot',
+        r'\toprule',
+        r'& Exp. $k_{\textrm{eff}}$&Exp. unc.& Calc. $k_{\textrm{eff}}$&Calc. unc.\\',
+        r'\midrule',
+        '% DATA',
+        '\\end{longtable}'
+    ]
 
     for case in index:
         # Obtain and format calculated values
         keff = df['keff'].loc[case]
         keff = num_format(keff)
-        
+
         stdev = df['stdev'].loc[case]
         stdev = num_format(stdev)
-        
+
         # Obtain and format experimental values
-        icsbep_keff = '{0:.4f}'.format(icsbep['keff'].loc[case])
-        icsbep_stdev = '{0:.4f}'.format(icsbep['stdev'].loc[case])
-        
+        icsbep_keff = '{:.4f}'.format(icsbep['keff'].loc[case])
+        icsbep_stdev = '{:.4f}'.format(icsbep['stdev'].loc[case])
+
         # Insert data values into table as separate entries
-        table.insert(-1, (f'{case}&{icsbep_keff}&{icsbep_stdev}&{keff}&{stdev}\\\\'))
+        table.insert(-1, rf'{case}&{icsbep_keff}&{icsbep_stdev}&{keff}&{stdev}\\')
 
     # Write all accumulated lines
-    tex.writelines(line + '\n' for line in (preamble + doc_start + table + doc_end))
-    tex.close()
-    return
+    with open(output, 'w') as tex:
+        tex.writelines('\n'.join(preamble + doc_start + table + doc_end))
+
 
 def main():
     """Produce LaTeX document with tabulated benchmark results"""
@@ -150,12 +137,7 @@ def main():
     parser = ArgumentParser()
     parser.add_argument('result', nargs='+', help='Result CSV file')
     parser.add_argument('--match', help='Pattern to match benchmark names to')
-    parser.add_argument('-o', '--output', help='Filename to save to')
+    parser.add_argument('-o', '--output', default='report.tex', help='Filename to save to')
     args = parser.parse_args()
-        
-    write_document(
-        args.result,
-        args.output,
-        args.match
-        )
-    
+
+    write_document(args.result, args.output, args.match)

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -11,9 +11,178 @@ import numpy as np
 from .results import get_result_dataframe, get_icsbep_dataframe, abbreviated_name
 
 
-import pylatex as pl
 
+def table(files, labels=None, match=None):
+    """Create a LaTeX table entry for all benchmark data comparing the calculated and
+    experimental values along with uncertainties.
+
+    Parameters
+    ----------
+    files : iterable of str
+        Name of a results file produced by the benchmarking script.
+    labels: iterable of str
+        Labels for each dataset to use in legend
+    match : str
+        Pattern to match benchmark names to
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        A matplotlib.axes.Axes object
+
+    """
+    if labels is None:
+        labels = [Path(f).name for f in files]
+
+    # Read data from spreadsheets
+    dataframes = {}
+    for csvfile, label in zip(files, labels):
+        dataframes[label] = get_result_dataframe(csvfile).dropna()
+
+    # Get model keff and uncertainty from ICSBEP
+    icsbep = get_icsbep_dataframe()
+
+    # Determine common benchmarks
+    base = labels[0]
+    index = dataframes[base].index
+    for df in dataframes.values():
+        index = index.intersection(df.index)
+
+    # Applying matching as needed
+    if match is not None:
+        cond = index.map(lambda x: fnmatch(x, match))
+        index = index[cond]
+
+    # entries are abbreviated_name, column 1
+    # experimental value, uncertainty, column 2,3
+    # calculated value, uncertainty, column 4, 5
+    
+    # Setup x values (integers) and corresponding tick labels
+    n = index.size
+    x = np.arange(1, n + 1)
+    xticklabels = index.map(abbreviated_name)
+
+    for i, (label, df) in enumerate(dataframes.items()):
+        # Calculate keff C/E and its standard deviation
+        coe = (df['keff'] / icsbep['keff']).loc[index]
+        stdev = 1.96 * df['stdev'].loc[index]
+
+        # Plot keff C/E
+        kwargs = {'color': f'C{i}', 'mec': 'black', 'mew': 0.15, 'label': label}
+        if show_uncertainties:
+            ax.errorbar(x, coe, yerr=stdev, fmt='o', **kwargs)
+        else:
+            ax.plot(x, coe, 'o', **kwargs)
+
+        # Plot mean C/E
+        if show_mean:
+            mu = coe.mean()
+            sigma = coe.std() / sqrt(n)
+            if show_shaded:
+                verts = [(0, mu - sigma), (0, mu + sigma), (n+1, mu + sigma), (n+1, mu - sigma)]
+                poly = Polygon(verts, facecolor=f'C{i}', alpha=0.5)
+                ax.add_patch(poly)
+            else:
+                ax.plot([-1, n], [mu, mu], '-', color=f'C{i}', lw=1.5)
+
+        # Show shaded region of benchmark model uncertainties
+        unc = icsbep['stdev'].loc[index]
+        vert = np.block([[x, x[::-1]], [1 + unc, 1 - unc[::-1]]]).T
+        poly = Polygon(vert, facecolor='gray', edgecolor=None, alpha=0.2)
+        ax.add_patch(poly)
+
+        # Define axes labels and title
+        ylabel = r'$k_\mathrm{eff}$ C/E'
+
+    # Configure plot
+    ax.set_axisbelow(True)
+    ax.set_xlim((0, n+1))
+    ax.set_xticks(x)
+    ax.set_xticklabels(xticklabels, rotation='vertical')
+    ax.tick_params(axis='x', which='major', labelsize=10)
+    ax.tick_params(axis='y', which='major', labelsize=14)
+    ax.set_xlabel('Benchmark case', fontsize=18)
+    ax.set_ylabel(ylabel, fontsize=18)
+    ax.grid(True, which='both', color='lightgray', ls='-', alpha=0.7)
+    ax.legend(numpoints=1)
+    pass
 
 def main():
-    """Produce .tex file"""
+    """Produce LaTeX document with tabulated benchmark results"""
+
+    parser = ArgumentParser()
+    #parser.add_argument('files', nargs='+', help='Result CSV files')
+    parser.add_argument('--labels', help='Comma-separated list of dataset labels')
+    #parser.add_argument('--plot-type', choices=['keff', 'diff'], default='keff')
+    parser.add_argument('--match', help='Pattern to match benchmark names to')
+    #parser.add_argument('--show-mean', action='store_true', help='Show line/bar indicating mean')
+    #parser.add_argument('--no-show-mean', dest='show_mean', action='store_false',
+    #                    help='Do not show line/bar indicating mean')
+    #parser.add_argument('--show-uncertainties', action='store_true',
+    #                    help='Show uncertainty bars on individual cases')
+    #parser.add_argument('--no-show-uncertainties', dest='show_uncertainties', action='store_false',
+    #                    help='Do not show uncertainty bars on individual cases')
+    #parser.add_argument('--show-shaded', action='store_true',
+    #                    help='Show shaded region indicating uncertainty of mean C/E')
+    #parser.add_argument('--no-show-shaded', dest='show_shaded', action='store_false',
+    #                    help='Do not show shaded region indicating uncertainty of mean C/E')
+    parser.add_argument('-o', '--output', help='Filename to save to')
+    #parser.add_argument('-c', '--compile', help='Compile resulting .tex to pdf')
+    parser.set_defaults(show_uncertainties=True, show_shaded=True, show_mean=True)
+    args = parser.parse_args()
     
+    if args.output is not None:
+        tex = open(args.output, 'w')
+    else:
+        tex = open('report.tex', 'w')
+    
+    if args.labels is not None:
+        args.labels = args.labels.split(',')
+    
+    # Testing purposes
+    preamble = ['\\documentclass[12pt]{article}', 
+                '\\usepackage[letterpaper, margin=1in]{geometry}',
+                '\\usepackage{dcolumn}',
+                '\\usepackage{tabularx}',
+                '\\usepackage{booktabs}',
+                '\\usepackage{longtable}',
+
+                '\\usepackage{fancyhdr}',
+                '\\setlength\\LTcapwidth{5.55in}',
+                '\\setlength\\LTleft{0.5in}',
+                '\\setlength\\LTright{0.5in}']
+    
+    tex.writelines(s + '\n' for s in preamble)
+        
+
+    document = ['\\begin{document}',
+                '\\part*{Benchmark Results}',
+                'Table \\ref{tab:tomato} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
+                '\\begin{longtable}{lcccc}',
+                '\\caption{\\label{tab:tomato} Criticality (nuclear data set info here) Benchmark Results}\\\\',
+                '\\endfirsthead',
+                '\\midrule',
+                '\\multicolumn{5}{r}{Continued on Next Page}\\',
+                '\\midrule',
+                '\\endfoot',
+                '\\bottomrule',
+                '\\endlastfoot',
+                '\\toprule',
+                '& Exp. $k_{\\textrm{eff}}$&Exp. unc.& Calc. $k_{\textrm{eff}}$&Calc. unc.\\',
+                '\\midrule',
+                'heu-met-fast-018-case-2&2.5&2.5&4.9 &5.3\\\\',
+                'heu-met-fast-019-case-2&2.5&2.5&4.3 &5.1\\\\',
+                'heu-met-fast-018-case-2&2.5&2.5&4.9 &5.3\\\\',
+                'heu-met-fast-019-case-2&2.5&2.5&4.3 &5.1\\\\',
+                'heu-met-fast-018-case-2&2.5&2.5&4.9 &5.3\\\\',
+                'heu-met-fast-019-case-2&2.5&2.5&4.3 &5.1\\\\',
+                'mix-comp-therm-002-case-pnl30&1.0010&0.0059&1.000\\,63 &0.000\\,333\\\\',
+                '\\end{longtable}',
+                '\\end{document}']
+    
+    tex.writelines(s + '\n' for s in document)
+
+
+
+    tex.close()
+

--- a/benchmarking/report.py
+++ b/benchmarking/report.py
@@ -34,17 +34,17 @@ def num_format(number):
             tex_number = number
     return tex_number
 
-def document(results, file, labels=None, match=None):
-    """Fill LaTeX document section with run info and table entries for all 
-    benchmark data comparing the calculated and experimental values along 
-    with uncertainties.
+def write_document(results, output='report.tex', labels=None, match=None):
+    """Write LaTeX document section with preamble, run info, and table entries 
+    for all benchmark data comparing the calculated and experimental values 
+    along with uncertainties.
 
     Parameters
     ----------
     results : iterable of str
         Name of a results file produced by the benchmarking script.
-    file    : str
-        Python variable assigned to 
+    output    : str
+        Name of the file to be written, ideally a .tex file
     labels: iterable of str
         Labels for each dataset to use in legend
     match : str
@@ -55,12 +55,26 @@ def document(results, file, labels=None, match=None):
     None
 
     """
+    #write .tex file
+    tex = open(output, 'w')
 
-    #define document start and end
-    document_start = ['\\begin{document}',
-                '\\part*{Benchmark Results}']
+    #define document preamble
+    preamble = ['\\documentclass[12pt]{article}', 
+                '\\usepackage[letterpaper, margin=1in]{geometry}',
+                '\\usepackage{dcolumn}',
+                '\\usepackage{tabularx}',
+                '\\usepackage{booktabs}',
+                '\\usepackage{longtable}',
+                '\\usepackage{fancyhdr}',
+                '\\setlength\\LTcapwidth{5.55in}',
+                '\\setlength\\LTleft{0.5in}',
+                '\\setlength\\LTright{0.5in}']
+
+    #define document start and end tex
+    doc_start = ['\\begin{document}',
+                 '\\part*{Benchmark Results}']
     
-    document_end = ['\\end{document}']
+    doc_end = ['\\end{document}']
 
     if labels is None:
         labels = [Path(f).name for f in files]
@@ -91,11 +105,9 @@ def document(results, file, labels=None, match=None):
     # Setup x values (integers) and corresponding tick labels
     n = index.size # <-- number of cases we need to issue
 
-
     x = np.arange(1, n + 1)
-    xticklabels = index.map(abbreviated_name)
 
-    table = ['Table \\ref{tab:tomato} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
+    table = ['Table \\ref{tab:data} uses (nuclear data set info here) to evaluate ICSBEP benchmarks.',
                 '\\begin{longtable}{lcccc}',
                 '\\caption{\\label{tab:tomato} Criticality (nuclear data set info here) Benchmark Results}\\\\',
                 '\\endfirsthead',
@@ -111,104 +123,45 @@ def document(results, file, labels=None, match=None):
                 '\\end{longtable}']
 
     for i, (label, df) in enumerate(dataframes.items()):
-        keff = 
-        decimal_index = keff.find('.') 
-        if decimal_index != -1:
-            
-        stdev =
+        keff = df['keff'].loc[index] #calculated
+        keff = num_format(keff)
+        stdev = df['stdev'].loc[index] #calculated?
+        stdev = num_format(stdev)
 
-        table.insert(-2, (f'{label}&{icsbep['keff']}&{icsbep['stdev']}&{keff}&{stdev}\\\\'))
-        # Calculate keff C/E and its standard deviation
-        coe = (df['keff'] / icsbep['keff']).loc[index] # <-- how to get both keff values
-        stdev = 1.96 * df['stdev'].loc[index]
+        icsbep_keff = icsbep['keff'].loc[index]
+        icsbep_stdev = icsbep['stdev'].loc[index]
 
-        # Plot keff C/E
-        kwargs = {'color': f'C{i}', 'mec': 'black', 'mew': 0.15, 'label': label}
-        if show_uncertainties:
-            ax.errorbar(x, coe, yerr=stdev, fmt='o', **kwargs)
-        else:
-            ax.plot(x, coe, 'o', **kwargs)
-
-        # Plot mean C/E
-        if show_mean:
-            mu = coe.mean()
-            sigma = coe.std() / sqrt(n)
-            if show_shaded:
-                verts = [(0, mu - sigma), (0, mu + sigma), (n+1, mu + sigma), (n+1, mu - sigma)]
-                poly = Polygon(verts, facecolor=f'C{i}', alpha=0.5)
-                ax.add_patch(poly)
-            else:
-                ax.plot([-1, n], [mu, mu], '-', color=f'C{i}', lw=1.5)
-
-        # Show shaded region of benchmark model uncertainties
-        unc = icsbep['stdev'].loc[index] # <-- how to access iscbep stdev (will need to format)
-        vert = np.block([[x, x[::-1]], [1 + unc, 1 - unc[::-1]]]).T
-        poly = Polygon(vert, facecolor='gray', edgecolor=None, alpha=0.2)
-        ax.add_patch(poly)
-    
+        table.insert(-2, (f'{label}&{icsbep_keff}&{icsbep_stdev}&{keff}&{stdev}\\\\'))
 
     
+    tex.writelines(s + '\n' for s in (preamble + doc_start + table + doc_end))
 
-    
-    
-    
-    tex.writelines(s + '\n' for s in document)
+    tex.close()
 
 def main():
     """Produce LaTeX document with tabulated benchmark results"""
 
     parser = ArgumentParser()
-    #parser.add_argument('files', nargs='+', help='Result CSV files')
+    parser.add_argument('files', nargs='+', help='Result CSV files')
     parser.add_argument('--labels', help='Comma-separated list of dataset labels')
-    #parser.add_argument('--plot-type', choices=['keff', 'diff'], default='keff')
     parser.add_argument('--match', help='Pattern to match benchmark names to')
-    #parser.add_argument('--show-mean', action='store_true', help='Show line/bar indicating mean')
-    #parser.add_argument('--no-show-mean', dest='show_mean', action='store_false',
-    #                    help='Do not show line/bar indicating mean')
-    #parser.add_argument('--show-uncertainties', action='store_true',
-    #                    help='Show uncertainty bars on individual cases')
-    #parser.add_argument('--no-show-uncertainties', dest='show_uncertainties', action='store_false',
-    #                    help='Do not show uncertainty bars on individual cases')
-    #parser.add_argument('--show-shaded', action='store_true',
-    #                    help='Show shaded region indicating uncertainty of mean C/E')
-    #parser.add_argument('--no-show-shaded', dest='show_shaded', action='store_false',
-    #                    help='Do not show shaded region indicating uncertainty of mean C/E')
     parser.add_argument('-o', '--output', help='Filename to save to')
     #parser.add_argument('-c', '--compile', help='Compile resulting .tex to pdf')
     parser.set_defaults(show_uncertainties=True, show_shaded=True, show_mean=True)
     args = parser.parse_args()
     
-    if args.output is not None:
-        tex = open(args.output, 'w')
-    else:
-        tex = open('report.tex', 'w')
-    
     if args.labels is not None:
         args.labels = args.labels.split(',')
-
-
-
-    
     
     # Testing purposes
-    preamble = ['\\documentclass[12pt]{article}', 
-                '\\usepackage[letterpaper, margin=1in]{geometry}',
-                '\\usepackage{dcolumn}',
-                '\\usepackage{tabularx}',
-                '\\usepackage{booktabs}',
-                '\\usepackage{longtable}',
-
-                '\\usepackage{fancyhdr}',
-                '\\setlength\\LTcapwidth{5.55in}',
-                '\\setlength\\LTleft{0.5in}',
-                '\\setlength\\LTright{0.5in}']
-    
     tex.writelines(s + '\n' for s in preamble)
         
-
+    write_document(
+        args.files,
+        args.output,
+        args.labels,
+        args.match
+        )
     
-
-
-
-    tex.close()
-
+    if args.compile:
+        pass

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
             'openmc-validate-photon-production=validation.photon_production:main',
             'openmc-run-benchmarks=benchmarking.benchmark:main',
             'openmc-plot-benchmarks=benchmarking.plot:main',
+            'openmc-report-benchmarks=benchmarking.report:main',
         ]
     }
 )


### PR DESCRIPTION
This pull request adds an automated LaTeX report production capability with a new script `openmc-report-benchmarks`. It takes one result file produced by `openmc-run-benchmarks` and produces a .tex file containing a table comparing the calculated criticality values and standard deviations to experimental benchmark values. 